### PR TITLE
Update copyright footer info

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -7,3 +7,5 @@ define('NEWS_CATEGORY_ID', 6);
 
 // define('TOP_10_PAGE_ID', 548);
 define('TOP_10_PAGE_ID', 797); //prod
+// define('VIDEOS_AND_PICTURES', 2032);
+define('VIDEOS_AND_PICTURES', 2158); //prod

--- a/template-parts/footer.php
+++ b/template-parts/footer.php
@@ -79,7 +79,13 @@
             </div>
         </div>
 
+        <?php
+        $videos_and_pictures_post = get_post(VIDEOS_AND_PICTURES);
+        $videos_and_pictures_link = $videos_and_pictures_post ? get_permalink($videos_and_pictures_post->ID) : get_home_url();
+        ?>
+
         <div class="mt-12 pt-8 text-xs text-center border-t border-brand-darkgrey">
+            <p>В сайта се използват авторски текстове, <a href="<?php echo $videos_and_pictures_link; ?>" class="hover:text-brand-red">видео и снимки*</a>. Цитирането на източник Car Life by Dani е задължително!</p>
             &copy;<?php echo date("Y"); ?> <a href="<?php echo get_home_url(); ?>" class="hover:text-brand-red">carlifebydani.com</a> Всички права запазени!
         </div>
     </div>


### PR DESCRIPTION
The PR adds a new constant for the "Videos and pictures" page id which is then used as a link in the copyright section of the footer.

![Screenshot 2024-02-20 at 00 22 54](https://github.com/trepechov/carlifebydani/assets/1242621/53775ede-b78a-4a1d-9081-ede19828eb0f)
