### PR TITLE
🔧 Update the glightbox selector

### DIFF
--- a/js/glightbox.init.js
+++ b/js/glightbox.init.js
@@ -4,9 +4,9 @@ document.addEventListener('DOMContentLoaded', () => {
         // loop: true,
         // autoplayVideos: true,
         zoomable: true,
-        selector: '.wp-block-gallery a, .wp-block-image a[href*=carlifebydani]'
+        selector: '.wp-block-gallery a, .wp-block-image a[href*=carlifebydani.com]'
     });
 
     // Add the lightbox class to the gallery and image blocks. Use for custume styling
-    jQuery('.wp-block-gallery a, .wp-block-image a[href*=carlifebydani]').addClass('glightbox');
+    jQuery('.wp-block-gallery a, .wp-block-image a[href*=carlifebydani.com]').addClass('glightbox');
 });


### PR DESCRIPTION
To prevent conflict with `ref` query parameters containing the same word,  the PR updates the glightobx selector