### PR TITLE
Fix stale active-sheet cache and related collection pipeline bugs

### DIFF
--- a/plugins/ev-news-automator/admin/class-ena-admin.php
+++ b/plugins/ev-news-automator/admin/class-ena-admin.php
@@ -108,8 +108,13 @@ class ENA_Admin {
         $values['service_account_path'] = sanitize_text_field( $_POST['service_account_path'] ?? '' );
         $values['ga4_property_id']      = sanitize_text_field( $_POST['ga4_property_id'] ?? '' );
         $values['podcast_doc_id']       = sanitize_text_field( $_POST['podcast_doc_id'] ?? '' );
-        $values['max_articles']         = absint( $_POST['max_articles'] ?? 50 );
-        $values['max_script_articles']  = absint( $_POST['max_script_articles'] ?? 10 );
+        // A blank/zero submission would otherwise persist 0 and cause trim_to_max()
+        // to delete every row on the next run — fall back to the existing value instead.
+        $submitted_max = absint( $_POST['max_articles'] ?? 0 );
+        $values['max_articles'] = $submitted_max > 0 ? $submitted_max : $this->settings->get( 'max_articles', 50 );
+
+        $submitted_script_max = absint( $_POST['max_script_articles'] ?? 0 );
+        $values['max_script_articles'] = $submitted_script_max > 0 ? $submitted_script_max : $this->settings->get( 'max_script_articles', 10 );
 
         $age = sanitize_text_field( $_POST['article_age_limit'] ?? '1d' );
         $values['article_age_limit'] = in_array( $age, $allowed_ages, true ) ? $age : '1d';

--- a/plugins/ev-news-automator/admin/views/dashboard-page.php
+++ b/plugins/ev-news-automator/admin/views/dashboard-page.php
@@ -69,9 +69,10 @@
                         <?php echo esc_html( date_i18n( 'j M Y · H:i', strtotime( $status['timestamp'] ) ) ); ?>
                     </p>
                 <?php endif; ?>
-                <?php if ( $label === 'Last Sync' && ! empty( $status['rate_limited'] ) ) : ?>
+                <?php if ( $label === 'Last Sync' && ! empty( $status['skipped'] ) ) : ?>
                     <p style="margin:8px 0 0;padding:6px 8px;background:#fef8ee;border-left:3px solid #dba617;color:#8a5a00;font-size:12px;">
-                        ⚠ <?php echo esc_html( $status['rate_limited'] ); ?> article(s) skipped — OpenRouter rate limit (429).
+                        ⚠ <?php echo esc_html( $status['skipped'] ); ?> article(s) skipped —
+                        <?php echo esc_html( $status['skip_summary'] ?? '' ); ?>.
                         <a href="#ena-account-card">Check OpenRouter account</a>.
                     </p>
                 <?php endif; ?>

--- a/plugins/ev-news-automator/admin/views/dashboard-page.php
+++ b/plugins/ev-news-automator/admin/views/dashboard-page.php
@@ -69,6 +69,12 @@
                         <?php echo esc_html( date_i18n( 'j M Y · H:i', strtotime( $status['timestamp'] ) ) ); ?>
                     </p>
                 <?php endif; ?>
+                <?php if ( $label === 'Last Sync' && ! empty( $status['rate_limited'] ) ) : ?>
+                    <p style="margin:8px 0 0;padding:6px 8px;background:#fef8ee;border-left:3px solid #dba617;color:#8a5a00;font-size:12px;">
+                        ⚠ <?php echo esc_html( $status['rate_limited'] ); ?> article(s) skipped — OpenRouter rate limit (429).
+                        <a href="#ena-account-card">Check OpenRouter account</a>.
+                    </p>
+                <?php endif; ?>
                 <?php if ( $label === 'Collection' && $sheet_url ) : ?>
                     <p style="margin:4px 0;">
                         <strong>Sheet URL:</strong>

--- a/plugins/ev-news-automator/assets/admin.css
+++ b/plugins/ev-news-automator/assets/admin.css
@@ -36,6 +36,13 @@
     color: #8a1c1c;
 }
 
+#ena-job-bar.is-warning {
+    display: flex;
+    background: #fef8ee;
+    border-left: 3px solid #dba617;
+    color: #8a5a00;
+}
+
 #ena-job-elapsed {
     margin-left: auto;
     font-size: 12px;

--- a/plugins/ev-news-automator/assets/admin.js
+++ b/plugins/ev-news-automator/assets/admin.js
@@ -201,6 +201,12 @@
         if (jobState.status === 'running') startPolling();
     }
 
+    // Load OpenRouter account usage (credits used/remaining) immediately rather than
+    // waiting for a manual "Refresh" click — it's the first thing worth seeing on load.
+    if (document.getElementById('ena-account-card')) {
+        fetchUsage();
+    }
+
     // ── OpenRouter Usage ──────────────────────────────────────────────────────
 
     function fmt(n) {

--- a/plugins/ev-news-automator/assets/admin.js
+++ b/plugins/ev-news-automator/assets/admin.js
@@ -90,8 +90,8 @@
             ? 'took ' + (job.finished_at - job.started_at) + 's'
             : '';
 
-        if (result.rate_limited) {
-            msg += ' · ⚠ ' + result.rate_limited + ' skipped (OpenRouter rate limited — check your account credits/limits)';
+        if (result.skipped) {
+            msg += ' · ⚠ ' + result.skipped + ' skipped (' + (result.skip_summary || 'OpenRouter errors') + ')';
             setBar('is-warning', '⚠', msg, duration);
         } else {
             setBar('is-done', '✓', msg, duration);

--- a/plugins/ev-news-automator/assets/admin.js
+++ b/plugins/ev-news-automator/assets/admin.js
@@ -90,7 +90,12 @@
             ? 'took ' + (job.finished_at - job.started_at) + 's'
             : '';
 
-        setBar('is-done', '✓', msg, duration);
+        if (result.rate_limited) {
+            msg += ' · ⚠ ' + result.rate_limited + ' skipped (OpenRouter rate limited — check your account credits/limits)';
+            setBar('is-warning', '⚠', msg, duration);
+        } else {
+            setBar('is-done', '✓', msg, duration);
+        }
     }
 
     function showError(job) {

--- a/plugins/ev-news-automator/ev-news-automator.php
+++ b/plugins/ev-news-automator/ev-news-automator.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: EV News Automator
  * Description: Automated Bulgarian EV news collection, summarization, and podcast script generation.
- * Version: 1.1.6
+ * Version: 1.1.7
  * Author: Car Life by Dani
  * Text Domain: ev-news-automator
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'ENA_VERSION',          '1.1.6' );
+define( 'ENA_VERSION',          '1.1.7' );
 define( 'ENA_PLUGIN_FILE',      __FILE__ );
 define( 'ENA_PLUGIN_DIR',       plugin_dir_path( __FILE__ ) );
 define( 'ENA_PLUGIN_URL',       plugin_dir_url( __FILE__ ) );

--- a/plugins/ev-news-automator/ev-news-automator.php
+++ b/plugins/ev-news-automator/ev-news-automator.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: EV News Automator
  * Description: Automated Bulgarian EV news collection, summarization, and podcast script generation.
- * Version: 1.1.3
+ * Version: 1.1.4
  * Author: Car Life by Dani
  * Text Domain: ev-news-automator
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'ENA_VERSION',          '1.1.3' );
+define( 'ENA_VERSION',          '1.1.4' );
 define( 'ENA_PLUGIN_FILE',      __FILE__ );
 define( 'ENA_PLUGIN_DIR',       plugin_dir_path( __FILE__ ) );
 define( 'ENA_PLUGIN_URL',       plugin_dir_url( __FILE__ ) );

--- a/plugins/ev-news-automator/ev-news-automator.php
+++ b/plugins/ev-news-automator/ev-news-automator.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: EV News Automator
  * Description: Automated Bulgarian EV news collection, summarization, and podcast script generation.
- * Version: 1.1.5
+ * Version: 1.1.6
  * Author: Car Life by Dani
  * Text Domain: ev-news-automator
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'ENA_VERSION',          '1.1.5' );
+define( 'ENA_VERSION',          '1.1.6' );
 define( 'ENA_PLUGIN_FILE',      __FILE__ );
 define( 'ENA_PLUGIN_DIR',       plugin_dir_path( __FILE__ ) );
 define( 'ENA_PLUGIN_URL',       plugin_dir_url( __FILE__ ) );

--- a/plugins/ev-news-automator/ev-news-automator.php
+++ b/plugins/ev-news-automator/ev-news-automator.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: EV News Automator
  * Description: Automated Bulgarian EV news collection, summarization, and podcast script generation.
- * Version: 1.1.7
+ * Version: 1.1.8
  * Author: Car Life by Dani
  * Text Domain: ev-news-automator
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'ENA_VERSION',          '1.1.7' );
+define( 'ENA_VERSION',          '1.1.8' );
 define( 'ENA_PLUGIN_FILE',      __FILE__ );
 define( 'ENA_PLUGIN_DIR',       plugin_dir_path( __FILE__ ) );
 define( 'ENA_PLUGIN_URL',       plugin_dir_url( __FILE__ ) );

--- a/plugins/ev-news-automator/ev-news-automator.php
+++ b/plugins/ev-news-automator/ev-news-automator.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: EV News Automator
  * Description: Automated Bulgarian EV news collection, summarization, and podcast script generation.
- * Version: 1.1.10
+ * Version: 1.1.4
  * Author: Car Life by Dani
  * Text Domain: ev-news-automator
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'ENA_VERSION',          '1.1.10' );
+define( 'ENA_VERSION',          '1.1.4' );
 define( 'ENA_PLUGIN_FILE',      __FILE__ );
 define( 'ENA_PLUGIN_DIR',       plugin_dir_path( __FILE__ ) );
 define( 'ENA_PLUGIN_URL',       plugin_dir_url( __FILE__ ) );

--- a/plugins/ev-news-automator/ev-news-automator.php
+++ b/plugins/ev-news-automator/ev-news-automator.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: EV News Automator
  * Description: Automated Bulgarian EV news collection, summarization, and podcast script generation.
- * Version: 1.1.9
+ * Version: 1.1.10
  * Author: Car Life by Dani
  * Text Domain: ev-news-automator
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'ENA_VERSION',          '1.1.9' );
+define( 'ENA_VERSION',          '1.1.10' );
 define( 'ENA_PLUGIN_FILE',      __FILE__ );
 define( 'ENA_PLUGIN_DIR',       plugin_dir_path( __FILE__ ) );
 define( 'ENA_PLUGIN_URL',       plugin_dir_url( __FILE__ ) );

--- a/plugins/ev-news-automator/ev-news-automator.php
+++ b/plugins/ev-news-automator/ev-news-automator.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: EV News Automator
  * Description: Automated Bulgarian EV news collection, summarization, and podcast script generation.
- * Version: 1.1.4
+ * Version: 1.1.5
  * Author: Car Life by Dani
  * Text Domain: ev-news-automator
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'ENA_VERSION',          '1.1.4' );
+define( 'ENA_VERSION',          '1.1.5' );
 define( 'ENA_PLUGIN_FILE',      __FILE__ );
 define( 'ENA_PLUGIN_DIR',       plugin_dir_path( __FILE__ ) );
 define( 'ENA_PLUGIN_URL',       plugin_dir_url( __FILE__ ) );

--- a/plugins/ev-news-automator/ev-news-automator.php
+++ b/plugins/ev-news-automator/ev-news-automator.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: EV News Automator
  * Description: Automated Bulgarian EV news collection, summarization, and podcast script generation.
- * Version: 1.1.8
+ * Version: 1.1.9
  * Author: Car Life by Dani
  * Text Domain: ev-news-automator
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'ENA_VERSION',          '1.1.8' );
+define( 'ENA_VERSION',          '1.1.9' );
 define( 'ENA_PLUGIN_FILE',      __FILE__ );
 define( 'ENA_PLUGIN_DIR',       plugin_dir_path( __FILE__ ) );
 define( 'ENA_PLUGIN_URL',       plugin_dir_url( __FILE__ ) );

--- a/plugins/ev-news-automator/includes/class-ena-collector.php
+++ b/plugins/ev-news-automator/includes/class-ena-collector.php
@@ -4,7 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class ENA_Collector {
 
     // Spacing between OpenRouter calls so a full batch doesn't burst past the account's rate limit.
-    private const REQUEST_DELAY_SECONDS = 2;
+    // OpenRouter's free-tier (:free models) cap is 20 requests/minute (1 per 3s); 4s keeps a safety
+    // margin below that even accounting for request latency and jitter.
+    private const REQUEST_DELAY_SECONDS = 4;
 
     private ENA_Sheets     $storage;
     private ENA_Scraper    $scraper;

--- a/plugins/ev-news-automator/includes/class-ena-collector.php
+++ b/plugins/ev-news-automator/includes/class-ena-collector.php
@@ -71,8 +71,9 @@ class ENA_Collector {
         // Sort by published_at DESC so articles are appended in recency order within each batch.
         usort( $new_articles, fn ( $a, $b ) => $b['published_at'] <=> $a['published_at'] );
 
-        $rows  = [];
-        $total = count( $new_articles );
+        $rows          = [];
+        $total         = count( $new_articles );
+        $rate_limited  = 0;
 
         foreach ( $new_articles as $i => $article ) {
             $num = $i + 1;
@@ -82,6 +83,7 @@ class ENA_Collector {
             $summary = $this->openrouter->summarize( $article['title'], $article['excerpt'] ?? '' );
 
             if ( is_wp_error( $summary ) ) {
+                if ( $summary->get_error_code() === 'http_429' ) $rate_limited++;
                 $this->logger->step( 'openrouter_call', 'skip', "article {$num}/{$total} — skipped, will retry next run: " . $summary->get_error_message() );
                 continue;
             }
@@ -114,8 +116,16 @@ class ENA_Collector {
             }
         }
 
+        if ( $rate_limited > 0 ) {
+            $this->logger->step(
+                'openrouter_rate_limit',
+                'warn',
+                "{$rate_limited}/{$total} articles skipped — OpenRouter rate limit (429) persisted through retries. Check your OpenRouter account credits/limits."
+            );
+        }
+
         // Sorting and trimming happen in ENA_Cron::run_pipeline() AFTER this returns,
         // so they operate on the full set (existing + newly appended) rows.
-        return [ 'added' => $added ];
+        return [ 'added' => $added, 'rate_limited' => $rate_limited ];
     }
 }

--- a/plugins/ev-news-automator/includes/class-ena-collector.php
+++ b/plugins/ev-news-automator/includes/class-ena-collector.php
@@ -32,6 +32,8 @@ class ENA_Collector {
         $new_articles  = [];
         $batch_seen    = [];
 
+        $this->logger->step( 'existing_urls', 'ok', count( $existing_urls ) . ' URLs already in active sheet (used for dedup)' );
+
         $cutoff   = $this->settings->article_age_cutoff();
         $html_cap = 5; // HTML pages carry no dates; top N items are assumed most recent.
 

--- a/plugins/ev-news-automator/includes/class-ena-collector.php
+++ b/plugins/ev-news-automator/includes/class-ena-collector.php
@@ -71,9 +71,9 @@ class ENA_Collector {
         // Sort by published_at DESC so articles are appended in recency order within each batch.
         usort( $new_articles, fn ( $a, $b ) => $b['published_at'] <=> $a['published_at'] );
 
-        $rows          = [];
-        $total         = count( $new_articles );
-        $rate_limited  = 0;
+        $rows         = [];
+        $total        = count( $new_articles );
+        $skip_reasons = []; // WP_Error code => count, so any systematic failure is visible, not just 429s.
 
         foreach ( $new_articles as $i => $article ) {
             $num = $i + 1;
@@ -83,7 +83,8 @@ class ENA_Collector {
             $summary = $this->openrouter->summarize( $article['title'], $article['excerpt'] ?? '' );
 
             if ( is_wp_error( $summary ) ) {
-                if ( $summary->get_error_code() === 'http_429' ) $rate_limited++;
+                $code = $summary->get_error_code();
+                $skip_reasons[ $code ] = ( $skip_reasons[ $code ] ?? 0 ) + 1;
                 $this->logger->step( 'openrouter_call', 'skip', "article {$num}/{$total} — skipped, will retry next run: " . $summary->get_error_message() );
                 continue;
             }
@@ -116,16 +117,35 @@ class ENA_Collector {
             }
         }
 
-        if ( $rate_limited > 0 ) {
+        $skipped = array_sum( $skip_reasons );
+        $skip_summary = implode( ', ', array_map(
+            fn ( $code, $n ) => "{$n}× " . self::describe_error_code( $code ),
+            array_keys( $skip_reasons ),
+            $skip_reasons
+        ) );
+
+        if ( $skipped > 0 ) {
             $this->logger->step(
-                'openrouter_rate_limit',
+                'openrouter_failures',
                 'warn',
-                "{$rate_limited}/{$total} articles skipped — OpenRouter rate limit (429) persisted through retries. Check your OpenRouter account credits/limits."
+                "{$skipped}/{$total} articles skipped — {$skip_summary}"
             );
         }
 
         // Sorting and trimming happen in ENA_Cron::run_pipeline() AFTER this returns,
         // so they operate on the full set (existing + newly appended) rows.
-        return [ 'added' => $added, 'rate_limited' => $rate_limited ];
+        return [ 'added' => $added, 'skipped' => $skipped, 'skip_summary' => $skip_summary ];
+    }
+
+    /** Human-readable explanation for a WP_Error code coming out of ENA_OpenRouter::summarize(). */
+    private static function describe_error_code( string $code ): string {
+        return match ( $code ) {
+            'http_401'         => 'authentication failed (401) — check your OpenRouter API key in Settings',
+            'http_429'         => 'rate limited (429) — check your OpenRouter account credits/limits',
+            'openrouter_key'   => 'no OpenRouter API key configured',
+            'openrouter_parse' => 'invalid response from OpenRouter',
+            'openrouter_empty' => 'empty response from OpenRouter',
+            default            => "OpenRouter error ({$code})",
+        };
     }
 }

--- a/plugins/ev-news-automator/includes/class-ena-cron.php
+++ b/plugins/ev-news-automator/includes/class-ena-cron.php
@@ -63,6 +63,12 @@ class ENA_Cron {
         // any articles published during this run's execution window.
         $run_started_at = time();
 
+        // Bypass the 5-minute sheets-list cache so a weekly tab added just before
+        // this run (e.g. right before clicking "Run collection now") is picked up
+        // as the active sheet instead of whatever was cached by an earlier page
+        // load or run.
+        $plugin->storage->flush_sheets_cache();
+
         // 1. Refresh clicks + votes on existing rows. Each GA4 fetch is logged
         //    independently so one failing fetch never blocks the others.
         $rows   = $plugin->storage->read_data_rows();

--- a/plugins/ev-news-automator/includes/class-ena-cron.php
+++ b/plugins/ev-news-automator/includes/class-ena-cron.php
@@ -139,7 +139,8 @@ class ENA_Cron {
             'timestamp'    => ( new DateTimeImmutable() )->format( 'c' ),
             'added'        => $result['added'] ?? 0,
             'removed'      => $removed,
-            'rate_limited' => $result['rate_limited'] ?? 0,
+            'skipped'      => $result['skipped'] ?? 0,
+            'skip_summary' => $result['skip_summary'] ?? '',
         ] );
 
         // 5. Rebuild the live snapshot for the feed page.

--- a/plugins/ev-news-automator/includes/class-ena-cron.php
+++ b/plugins/ev-news-automator/includes/class-ena-cron.php
@@ -69,10 +69,22 @@ class ENA_Cron {
         // load or run.
         $plugin->storage->flush_sheets_cache();
 
+        // Log which tab this run resolved as "active" before touching any data —
+        // the single most useful line for diagnosing a run that targets the wrong
+        // sheet or wipes an unexpectedly-empty one.
+        $active_name = $plugin->storage->active_sheet_name();
+        $plugin->logger->step(
+            'active_sheet',
+            is_wp_error( $active_name ) ? 'error' : 'ok',
+            is_wp_error( $active_name ) ? $active_name->get_error_message() : "resolved active tab: {$active_name}"
+        );
+
         // 1. Refresh clicks + votes on existing rows. Each GA4 fetch is logged
         //    independently so one failing fetch never blocks the others.
         $rows   = $plugin->storage->read_data_rows();
         $urls   = is_wp_error( $rows ) ? [] : array_column( $rows, 'link' );
+        $plugin->logger->step( 'read_data_rows', is_wp_error( $rows ) ? 'error' : 'ok',
+            is_wp_error( $rows ) ? $rows->get_error_message() : count( $rows ) . ' existing rows read' );
         $clicks = $plugin->analytics->fetch_clicks( $urls );
 
         if ( is_wp_error( $clicks ) ) {
@@ -103,6 +115,7 @@ class ENA_Cron {
 
         // 2. Collect & append new articles at the bottom.
         $result = $plugin->collector->run();
+        $plugin->logger->step( 'row_count_after_collect', 'ok', $plugin->storage->row_count() . ' rows in active sheet after append' );
 
         // 3. Sort the full sheet (always — independent of the vote fetch above).
         $sort_result = $plugin->storage->sort_by_upvotes();
@@ -113,12 +126,13 @@ class ENA_Cron {
         }
 
         // 4. Trim to max by deleting the bottom (oldest zero-upvote) rows.
-        $max     = (int) $plugin->settings->get( 'max_articles', 50 );
-        $removed = $plugin->storage->trim_to_max( $max );
+        $max        = (int) $plugin->settings->get( 'max_articles', 50 );
+        $pre_trim   = $plugin->storage->row_count();
+        $plugin->logger->step( 'sheets_trim_start', 'ok', "max_articles={$max}, rows before trim={$pre_trim}" );
+        $removed    = $plugin->storage->trim_to_max( $max );
         $result['removed'] = $removed;
-        if ( $removed > 0 ) {
-            $plugin->logger->step( 'sheets_trim', 'ok', "{$removed} oldest zero-upvote rows removed (max={$max})" );
-        }
+        $plugin->logger->step( 'sheets_trim', 'ok',
+            "{$removed} rows removed (max={$max}), rows after trim=" . $plugin->storage->row_count() );
 
         // Collection status reflects this run's append + trim counts.
         $plugin->logger->set_status( ENA_OPT_STATUS_COLLECTION, [

--- a/plugins/ev-news-automator/includes/class-ena-cron.php
+++ b/plugins/ev-news-automator/includes/class-ena-cron.php
@@ -136,9 +136,10 @@ class ENA_Cron {
 
         // Collection status reflects this run's append + trim counts.
         $plugin->logger->set_status( ENA_OPT_STATUS_COLLECTION, [
-            'timestamp' => ( new DateTimeImmutable() )->format( 'c' ),
-            'added'     => $result['added'] ?? 0,
-            'removed'   => $removed,
+            'timestamp'    => ( new DateTimeImmutable() )->format( 'c' ),
+            'added'        => $result['added'] ?? 0,
+            'removed'      => $removed,
+            'rate_limited' => $result['rate_limited'] ?? 0,
         ] );
 
         // 5. Rebuild the live snapshot for the feed page.

--- a/plugins/ev-news-automator/includes/class-ena-sheets.php
+++ b/plugins/ev-news-automator/includes/class-ena-sheets.php
@@ -314,6 +314,8 @@ class ENA_Sheets {
      * Returns the number of rows removed.
      */
     public function trim_to_max( int $max ): int {
+        if ( $max <= 0 ) return 0; // Invalid/unset limit — never treat this as "delete everything."
+
         $count = $this->row_count();
         if ( $count <= $max ) return 0;
 

--- a/plugins/ev-news-automator/includes/class-ena-sheets.php
+++ b/plugins/ev-news-automator/includes/class-ena-sheets.php
@@ -366,6 +366,17 @@ class ENA_Sheets {
     }
 
     /**
+     * Force list_sheets() to hit the Sheets API on its next call instead of serving
+     * the 5-minute cache. Call this before resolving the active sheet for a pipeline
+     * run so a newly added weekly tab is picked up immediately rather than waiting
+     * out a cache warmed by an earlier page load or run.
+     */
+    public function flush_sheets_cache(): void {
+        $id = $this->settings->get( 'spreadsheet_id' );
+        delete_transient( 'ena_sheets_list_' . md5( (string) $id ) );
+    }
+
+    /**
      * Return the tab title of the most recently dated session sheet (DD.MM.YYYY format).
      */
     public function active_sheet_name(): string|WP_Error {


### PR DESCRIPTION
## Summary

The collection pipeline was resolving the wrong (previous week's) Google Sheets tab because the sheet-list cache had no invalidation. Fixing that surfaced several related bugs found during the same debugging session:

- **Stale active-sheet cache** — `list_sheets()` cached the tab list for 5 minutes with no invalidation, so a newly created weekly tab wasn't picked up until the cache expired. Now flushed before every pipeline run, with the resolved tab logged for diagnosis.
- **`max_articles=0` could wipe the sheet** — a blank/zero settings submission persisted as `0`, and `trim_to_max(0)` then deleted every row on the next run. Settings save now falls back to the existing value, and `trim_to_max()` guards against `<= 0` directly.
- **Silent OpenRouter failures** — batches failing entirely (401 auth errors, 429 rate limits) previously reported as a quiet "success" with 0 articles added. Failures are now tallied by error code and surfaced as a visible warning on the dashboard and job status bar.
- **Request pacing** — bumped the delay between OpenRouter calls (2s → 4s) to stay under the free-tier 20 req/min cap with margin for latency/jitter.
- **Dashboard** — OpenRouter account usage now loads automatically on page open instead of requiring a manual refresh click.
- Added step-by-step transcript logging (active sheet resolved, row counts at each stage) to make future pipeline issues easier to diagnose.

## Test plan
- [ ] Run collection manually and confirm the newly created weekly tab is used as the active sheet immediately (no 5-min wait)
- [ ] Save settings with a blank "Max Articles" field and confirm the existing value is preserved, not 0
- [ ] Confirm a run with OpenRouter failures shows the skip warning with a correct reason (401 vs 429) in both the dashboard card and job bar